### PR TITLE
Detalles de los filtros de GetCarreras y metodo de movido de carreras…

### DIFF
--- a/AvaluoAPI/Data de Prueba.sql
+++ b/AvaluoAPI/Data de Prueba.sql
@@ -23,13 +23,25 @@ INSERT INTO metodo_evaluacion (descripcionES, descripcionEN) VALUES
 ('Proyecto', 'Project'),
 ('Presentación', 'Presentation');
 
-INSERT INTO Roles (Descripcion) VALUES
-('Profesor'),
-('Administrador'),
-('Coordinador'),
-('Supervisor'),
-('Auxiliar'),
-('Prueba')
+INSERT INTO roles (
+    Descripcion, 
+    EsProfesor, 
+    EsSupervisor, 
+    EsCoordinadorArea, 
+    EsCoordinadorCarrera, 
+    EsAdmin, 
+    EsAux, 
+    VerInformes, 
+    VerListaDeRubricas, 
+    ConfigurarFechas, 
+    VerManejoCurriculum
+) VALUES
+('Profesor', 1, 0, 0, 0, 0, 0, 1, 1, 0, 1),
+('Administrador', 0, 0, 0, 0, 1, 0, 1, 1, 1, 1),
+('Coordinador', 0, 0, 1, 1, 0, 0, 1, 1, 1, 1),
+('Supervisor', 0, 1, 0, 0, 0, 0, 1, 1, 1, 1),
+('Auxiliar', 0, 0, 0, 0, 0, 1, 0, 0, 0, 0),
+('Prueba', 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
 
 INSERT INTO tipo_competencia (Nombre) VALUES
 ('Específica'),

--- a/AvaluoAPI/Domain/Services/AsignaturaService/AsignaturaService.cs
+++ b/AvaluoAPI/Domain/Services/AsignaturaService/AsignaturaService.cs
@@ -35,6 +35,15 @@ namespace AvaluoAPI.Domain.Services.AsignaturaService
             return await _unitOfWork.Asignaturas.GetAsignaturas(codigo, nombre, idEstado, idArea, page, recordsPerPage);
         }
 
+        public async Task<PaginatedResult<AsignaturaViewModel>> GetSubjectByCareer(int idCarrera, int? page, int? recordsPerPage)
+        {
+            var carrera = await _unitOfWork.Carreras.GetByIdAsync(idCarrera);
+            if (carrera == null)
+                throw new KeyNotFoundException("Carrera especificada no encontrada.");
+
+            return await _unitOfWork.AsignaturasCarreras.GetAllByCareer(idCarrera, page, recordsPerPage);
+        }
+
         public async Task Register(AsignaturaDTO asignaturaDTO)
         {  
             var area = await _unitOfWork.Areas.GetByIdAsync(asignaturaDTO.IdArea);

--- a/AvaluoAPI/Domain/Services/AsignaturaService/IAsignaturaService.cs
+++ b/AvaluoAPI/Domain/Services/AsignaturaService/IAsignaturaService.cs
@@ -5,11 +5,12 @@ namespace AvaluoAPI.Domain.Services.AsignaturaService
 {
     public interface IAsignaturaService
     {
-        Task<PaginatedResult<AsignaturaViewModel>> GetAll(string? codigo, string? nombre, int? idEstado, int? idArea, int? page, int? recordsPerPage);
-        Task<AsignaturaViewModel> GetById(int id);
-        Task Register(AsignaturaDTO asignaturaDTO);
-        Task Update(int id, AsignaturaModifyDTO asignaturaDTO);
-        Task Delete(int id);
+        Task<PaginatedResult<AsignaturaViewModel>> GetAll(string? codigo, string? nombre, int? idEstado, int? idArea, int? page, int? recordsPerPage); // Obtiene una lista paginada de asignaturas con filtros opcionales.
+        Task<AsignaturaViewModel> GetById(int id); // Obtiene una asignatura por su ID.
+        Task<PaginatedResult<AsignaturaViewModel>> GetSubjectByCareer(int idCarrera, int? page, int? recordsPerPage); // Obtiene una lista paginada de asignaturas asociadas a una carrera específica.
+        Task Register(AsignaturaDTO asignaturaDTO); // Registra una nueva asignatura.
+        Task Update(int id, AsignaturaModifyDTO asignaturaDTO); // Actualiza una asignatura existente con base en su ID.
+        Task Delete(int id); // Elimina una asignatura por su ID.
     }
 
 }

--- a/AvaluoAPI/Domain/Services/CarrerasService/CarreraService.cs
+++ b/AvaluoAPI/Domain/Services/CarrerasService/CarreraService.cs
@@ -6,6 +6,7 @@ using MapsterMapper;
 using System.ComponentModel.DataAnnotations;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Drawing;
 
 namespace AvaluoAPI.Domain.Services.CarreraService
 {
@@ -20,19 +21,19 @@ namespace AvaluoAPI.Domain.Services.CarreraService
             _mapper = mapper;
         }
 
-        // Obtener todas las carreras con filtros y paginación
         public async Task<PaginatedResult<CarreraViewModel>> GetAll(
             string? nombreCarrera,
             int? idEstado,
             int? idArea,
             int? idCoordinadorCarrera,
+            int? año, 
+            string? peos,
             int? page,
             int? recordsPerPage)
         {
-            return await _unitOfWork.Carreras.GetCarreras(nombreCarrera, idEstado, idArea, idCoordinadorCarrera, page, recordsPerPage);
+            return await _unitOfWork.Carreras.GetCarreras(nombreCarrera, idEstado, idArea, idCoordinadorCarrera, año, peos, page, recordsPerPage);
         }
 
-        // Obtener una carrera por ID con su Estado y Área
         public async Task<CarreraViewModel> GetById(int id)
         {
             var carrera = await _unitOfWork.Carreras.GetCarreraById(id);
@@ -42,26 +43,16 @@ namespace AvaluoAPI.Domain.Services.CarreraService
             return carrera;
         }
 
-        public async Task<IEnumerable<AsignaturaCarreraViewModel>> GetSubjectByCareer(int? idCarrera)
-        {
-            var asignaturasCarreras = await _unitOfWork.AsignaturasCarreras.GetAllByCareer(idCarrera);
-            return _mapper.Map<IEnumerable<AsignaturaCarreraViewModel>>(asignaturasCarreras);
-        }
-
-        // Registrar una nueva carrera
         public async Task Register(CarreraDTO carreraDTO)
         {
-            // Validar que el área exista
             var area = await _unitOfWork.Areas.GetByIdAsync(carreraDTO.IdArea);
             if (area == null)
                 throw new KeyNotFoundException("El área especificada no existe.");
 
-            // Obtener el estado por defecto
             var estadoPorDefecto = await _unitOfWork.Estados.GetEstadoByTablaName("Carrera", "Activa");
             if (estadoPorDefecto == null)
                 throw new KeyNotFoundException("No se encontró un estado por defecto para 'Carrera'.");
 
-            // Validar que el coordinador exista
             var coordinador = await _unitOfWork.Usuarios.GetUsuarioWithRolById(carreraDTO.IdCoordinadorCarrera);
             if (coordinador == null)
                 throw new KeyNotFoundException("El usuario especificado no existe.");
@@ -69,36 +60,30 @@ namespace AvaluoAPI.Domain.Services.CarreraService
             if(coordinador?.Rol?.EsCoordinadorCarrera != true) 
                 throw new KeyNotFoundException("El usuario especificado no tiene el rol de Coordinador de Carrera");
 
-            // Mapear DTO a Entidad
             var carrera = _mapper.Map<Carrera>(carreraDTO);
             carrera.UltimaEdicion = DateTime.UtcNow;
             carrera.IdEstado = estadoPorDefecto.Id;
 
-            // Guardar en la base de datos
             await _unitOfWork.Carreras.AddAsync(carrera);
             _unitOfWork.SaveChanges();
         }
 
-        // Actualizar una carrera existente
         public async Task Update(int id, CarreraModifyDTO carreraDTO)
         {
             var carrera = await _unitOfWork.Carreras.GetByIdAsync(id);
             if (carrera == null)
                 throw new KeyNotFoundException("Carrera no encontrada.");
 
-            // Validar que el área exista
             var area = await _unitOfWork.Areas.GetByIdAsync(carreraDTO.IdArea);
             if (area == null)
                 throw new KeyNotFoundException("El área especificada no existe.");
 
-            // Validar que el estado exista y pertenezca a 'Carrera'
             var estado = await _unitOfWork.Estados.GetByIdAsync(carreraDTO.IdEstado);
             if (estado == null)
                 throw new KeyNotFoundException("El estado especificado no existe.");
             if (estado.IdTabla != "Carrera")
                 throw new ValidationException("El estado especificado no pertenece a 'Carrera'.");
 
-            // Validar que el coordinador exista
             var coordinador = await _unitOfWork.Usuarios.GetUsuarioWithRolById(carreraDTO.IdCoordinadorCarrera);
             if (coordinador == null)
                 throw new KeyNotFoundException("El usuario especificado no existe.");
@@ -106,11 +91,9 @@ namespace AvaluoAPI.Domain.Services.CarreraService
             if (coordinador?.Rol?.EsCoordinadorCarrera != true)
                 throw new KeyNotFoundException("El usuario especificado no tiene el rol de Coordinador de Carrera");
 
-            // Mapear DTO a Entidad
             _mapper.Map(carreraDTO, carrera);
             carrera.UltimaEdicion = DateTime.UtcNow;
 
-            // Guardar cambios en la base de datos
             await _unitOfWork.Carreras.Update(carrera);
             _unitOfWork.SaveChanges();
         }
@@ -127,8 +110,6 @@ namespace AvaluoAPI.Domain.Services.CarreraService
             _unitOfWork.SaveChanges();
         }
 
-
-        // Eliminar una carrera
         public async Task Delete(int id)
         {
             var carrera = await _unitOfWork.Carreras.GetByIdAsync(id);

--- a/AvaluoAPI/Domain/Services/CarrerasService/ICarreraService.cs
+++ b/AvaluoAPI/Domain/Services/CarrerasService/ICarreraService.cs
@@ -5,14 +5,13 @@ namespace AvaluoAPI.Domain.Services.CarreraService
 {
     public interface ICarreraService
     {
-        Task<PaginatedResult<CarreraViewModel>> GetAll(string? nombreCarrera, int? idEstado, int? idArea, int? idCoordinadorCarrera, int? page, int? recordsPerPage);
-        Task<CarreraViewModel> GetById(int id);
-        Task Register(CarreraDTO CarreraDTO);
-        Task Update(int id, CarreraModifyDTO CarreraDTO);
-        Task Delete(int id);
-        Task UpdatePEOs(int id, string nuevosPEOs);
-        Task<IEnumerable<AsignaturaCarreraViewModel>> GetSubjectByCareer(int? idCarrera);
-        Task<IEnumerable<AsignaturaConCompetenciasViewModel>> GetMapaCompetencias(int idCarrera, int idTipoCompetencia);
+        Task<PaginatedResult<CarreraViewModel>> GetAll(string? nombreCarrera, int? idEstado, int? idArea, int? idCoordinadorCarrera, int? año, string? peos, int? page, int? recordsPerPage); // Obtiene una lista paginada de carreras con filtros opcionales.
+        Task<CarreraViewModel> GetById(int id); // Obtiene una carrera por su ID.
+        Task Register(CarreraDTO CarreraDTO); // Registra una nueva carrera.
+        Task Update(int id, CarreraModifyDTO CarreraDTO); // Actualiza una carrera existente con base en su ID.
+        Task Delete(int id);  // Elimina una carrera por su ID.
+        Task UpdatePEOs(int id, string nuevosPEOs);  // Actualiza los PEOs (Program Educational Objectives) de una carrera específica.
+        Task<IEnumerable<AsignaturaConCompetenciasViewModel>> GetMapaCompetencias(int idCarrera, int idTipoCompetencia); // Obtiene el mapa de competencias de una carrera.
     }
 
 }

--- a/AvaluoAPI/Infrastructure/Persistence/Repositories/AsignaturasCarrerasRepositories/IAsignaturaCarreraRepository.cs
+++ b/AvaluoAPI/Infrastructure/Persistence/Repositories/AsignaturasCarrerasRepositories/IAsignaturaCarreraRepository.cs
@@ -6,7 +6,7 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.AsignaturasCarrerasR
 {
     public interface IAsignaturaCarreraRepository : IRepository<AsignaturaCarrera>
     {
-        Task<IEnumerable<AsignaturaCarreraViewModel>> GetAllByCareer(int? idCarrera);
+        Task<PaginatedResult<AsignaturaViewModel>> GetAllByCareer(int idCarrera, int? page, int? recordsPerPage);
         Task<List<int>> GetCarrerasIdsByAsignaturaId(int asignatura);
     }
 }

--- a/AvaluoAPI/Infrastructure/Persistence/Repositories/CarrerasRepositories/CarreraRepository.cs
+++ b/AvaluoAPI/Infrastructure/Persistence/Repositories/CarrerasRepositories/CarreraRepository.cs
@@ -51,7 +51,9 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.CarrerasRepositories
 
                 u.Id,
                 u.Nombre,
-                u.Email
+				u.Apellido,
+                u.Email,
+				u.Username
             FROM dbo.carreras c
             LEFT JOIN dbo.estado e ON c.IdEstado = e.Id
             LEFT JOIN dbo.areas ar ON c.IdArea = ar.Id
@@ -78,32 +80,38 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.CarrerasRepositories
 
         // Obtener todas las carreras con filtros y paginación
         public async Task<PaginatedResult<CarreraViewModel>> GetCarreras(
-            string? nombreCarrera,
-            int? idEstado,
-            int? idArea,
-            int? idCoordinadorCarrera,
-            int? page,
-            int? recordsPerPage)
+     string? nombreCarrera,
+     int? idEstado,
+     int? idArea,
+     int? idCoordinadorCarrera,
+     int? año,
+     string? peos,
+     int? page,
+     int? recordsPerPage)
         {
             using var connection = _dapperContext.CreateConnection();
 
             var countQuery = @"
-            SELECT COUNT(*)
-            FROM dbo.carreras c
-            LEFT JOIN dbo.estado e ON c.IdEstado = e.Id
-            LEFT JOIN dbo.areas ar ON c.IdArea = ar.Id
-            LEFT JOIN dbo.usuario u ON c.IdCoordinadorCarrera = u.Id
-            WHERE (@NombreCarrera IS NULL OR c.NombreCarrera LIKE '%' + @NombreCarrera + '%')
-            AND (@IdEstado IS NULL OR c.IdEstado = @IdEstado)
-            AND (@IdArea IS NULL OR c.IdArea = @IdArea)
-            AND (@IdCoordinadorCarrera IS NULL OR c.IdCoordinadorCarrera = @IdCoordinadorCarrera)";
+    SELECT COUNT(*)
+    FROM dbo.carreras c
+    LEFT JOIN dbo.estado e ON c.IdEstado = e.Id
+    LEFT JOIN dbo.areas ar ON c.IdArea = ar.Id
+    LEFT JOIN dbo.usuario u ON c.IdCoordinadorCarrera = u.Id
+    WHERE (@NombreCarrera IS NULL OR c.NombreCarrera LIKE '%' + @NombreCarrera + '%')
+    AND (@IdEstado IS NULL OR c.IdEstado = @IdEstado)
+    AND (@IdArea IS NULL OR c.IdArea = @IdArea)
+    AND (@IdCoordinadorCarrera IS NULL OR c.IdCoordinadorCarrera = @IdCoordinadorCarrera)
+    AND (@Año IS NULL OR c.Año = @Año)
+    AND (@PEOs IS NULL OR c.PEOs LIKE '%' + @PEOs + '%')";
 
             int totalRecords = await connection.ExecuteScalarAsync<int>(countQuery, new
             {
                 NombreCarrera = nombreCarrera,
                 IdEstado = idEstado,
                 IdArea = idArea,
-                IdCoordinadorCarrera = idCoordinadorCarrera
+                IdCoordinadorCarrera = idCoordinadorCarrera,
+                Año = año,
+                PEOs = peos
             });
 
             if (totalRecords == 0)
@@ -116,40 +124,44 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.CarrerasRepositories
             int offset = (currentPage - 1) * currentRecordsPerPage;
 
             var query = $@"
-            SELECT 
-                c.Id, 
-                c.Año, 
-                c.NombreCarrera, 
-                c.PEOs, 
-                c.FechaCreacion, 
-                c.UltimaEdicion, 
-                c.IdEstado, 
-                c.IdArea, 
-                c.IdCoordinadorCarrera,
+    SELECT 
+        c.Id, 
+        c.Año, 
+        c.NombreCarrera, 
+        c.PEOs, 
+        c.FechaCreacion, 
+        c.UltimaEdicion, 
+        c.IdEstado, 
+        c.IdArea, 
+        c.IdCoordinadorCarrera,
 
-                e.Id,
-                e.Descripcion,
-                e.IdTabla,
+        e.Id,
+        e.Descripcion,
+        e.IdTabla,
 
-                ar.Id,
-                ar.Descripcion,
-                ar.IdCoordinador,
-                ar.FechaCreacion,
-                ar.UltimaEdicion,
+        ar.Id,
+        ar.Descripcion,
+        ar.IdCoordinador,
+        ar.FechaCreacion,
+        ar.UltimaEdicion,
 
-                u.Id,
-                u.Nombre,
-                u.Email
-            FROM dbo.carreras c
-            LEFT JOIN dbo.estado e ON c.IdEstado = e.Id
-            LEFT JOIN dbo.areas ar ON c.IdArea = ar.Id
-            LEFT JOIN dbo.usuario u ON c.IdCoordinadorCarrera = u.Id
-            WHERE (@NombreCarrera IS NULL OR c.NombreCarrera LIKE '%' + @NombreCarrera + '%')
-            AND (@IdEstado IS NULL OR c.IdEstado = @IdEstado)
-            AND (@IdArea IS NULL OR c.IdArea = @IdArea)
-            AND (@IdCoordinadorCarrera IS NULL OR c.IdCoordinadorCarrera = @IdCoordinadorCarrera)
-            ORDER BY c.Id
-            OFFSET @Offset ROWS FETCH NEXT @RecordsPerPage ROWS ONLY";
+        u.Id,
+        u.Nombre,
+        u.Apellido,
+        u.Email,
+        u.Username
+    FROM dbo.carreras c
+    LEFT JOIN dbo.estado e ON c.IdEstado = e.Id
+    LEFT JOIN dbo.areas ar ON c.IdArea = ar.Id
+    LEFT JOIN dbo.usuario u ON c.IdCoordinadorCarrera = u.Id
+    WHERE (@NombreCarrera IS NULL OR c.NombreCarrera LIKE '%' + @NombreCarrera + '%')
+    AND (@IdEstado IS NULL OR c.IdEstado = @IdEstado)
+    AND (@IdArea IS NULL OR c.IdArea = @IdArea)
+    AND (@IdCoordinadorCarrera IS NULL OR c.IdCoordinadorCarrera = @IdCoordinadorCarrera)
+    AND (@Año IS NULL OR c.Año = @Año)
+    AND (@PEOs IS NULL OR c.PEOs LIKE '%' + @PEOs + '%')
+    ORDER BY c.Id
+    OFFSET @Offset ROWS FETCH NEXT @RecordsPerPage ROWS ONLY";
 
             var parametros = new
             {
@@ -157,6 +169,8 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.CarrerasRepositories
                 IdEstado = idEstado,
                 IdArea = idArea,
                 IdCoordinadorCarrera = idCoordinadorCarrera,
+                Año = año,
+                PEOs = peos,
                 Offset = offset,
                 RecordsPerPage = currentRecordsPerPage
             };

--- a/AvaluoAPI/Infrastructure/Persistence/Repositories/CarrerasRepositories/ICarreraRepository.cs
+++ b/AvaluoAPI/Infrastructure/Persistence/Repositories/CarrerasRepositories/ICarreraRepository.cs
@@ -7,7 +7,7 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.CarrerasRepositories
     public interface ICarreraRepository : IRepository<Carrera>
     {
         Task<CarreraViewModel?> GetCarreraById(int id);
-        Task<PaginatedResult<CarreraViewModel>> GetCarreras(string? nombreCarrera, int? idEstado, int? idArea, int? idCoordinadorCarrera, int? page, int? recordsPerPage);
+        Task<PaginatedResult<CarreraViewModel>> GetCarreras(string? nombreCarrera, int? idEstado, int? idArea, int? idCoordinadorCarrera, int? año, string? peos, int? page, int? recordsPerPage);
         Task<IEnumerable<AsignaturaConCompetenciasViewModel>> GetMapaCompetencias(int idCarrera, int idTipoCompetencia);
     }
 }

--- a/AvaluoAPI/Presentation/Controllers/AsignaturasController.cs
+++ b/AvaluoAPI/Presentation/Controllers/AsignaturasController.cs
@@ -33,6 +33,13 @@ namespace AvaluoAPI.Presentation.Controllers
             return Ok(new { mensaje = "Asignaturas obtenidas exitosamente.", data = asignaturas });
         }
 
+        [HttpGet("carrera/{idCarrera}")]
+        public async Task<ActionResult<IEnumerable<AsignaturaViewModel>>> GetByCareer(
+        int idCarrera, [FromQuery] int? page, int? recordsPerPage)
+        {
+            var asignaturasCarreras = await _asignaturaService.GetSubjectByCareer(idCarrera, page, recordsPerPage);
+            return Ok(new { mensaje = "Asignaturas por carrera obtenidas exitosamente.", data = asignaturasCarreras });
+        }
 
         // GET: api/Asignaturas/{id}
         [HttpGet("{id}")]

--- a/AvaluoAPI/Presentation/Controllers/CarrerasController.cs
+++ b/AvaluoAPI/Presentation/Controllers/CarrerasController.cs
@@ -20,23 +20,17 @@ namespace AvaluoAPI.Presentation.Controllers
         // GET: api/Carreras?nombreCarrera=Ingeniería&idEstado=1&idArea=2&idCoordinador=5&page=1&recordsPerPage=10
         [HttpGet]
         public async Task<ActionResult<PaginatedResult<CarreraViewModel>>> Get(
-            [FromQuery] string? nombreCarrera = null,
-            [FromQuery] int? idEstado = null,
-            [FromQuery] int? idArea = null,
-            [FromQuery] int? idCoordinador = null,
-            [FromQuery] int? page = null,
-            [FromQuery] int? recordsPerPage = null)
+            [FromQuery] string? nombreCarrera,
+            [FromQuery] int? año,
+            [FromQuery] string? peos,
+            [FromQuery] int? idEstado,
+            [FromQuery] int? idArea,
+            [FromQuery] int? idCoordinador,
+            [FromQuery] int? page,
+            [FromQuery] int? recordsPerPage)
         {
-            var carreras = await _carreraService.GetAll(nombreCarrera, idEstado, idArea, idCoordinador, page, recordsPerPage);
+            var carreras = await _carreraService.GetAll(nombreCarrera, idEstado, idArea, idCoordinador,año, peos, page, recordsPerPage);
             return Ok(new { mensaje = "Carreras obtenidas exitosamente.", data = carreras });
-        }
-
-        [HttpGet("asignaturas")]
-        public async Task<ActionResult<IEnumerable<AsignaturaCarreraViewModel>>> GetSubject(
-        [FromQuery] int? idCarrera)
-        {
-            var asignaturasCarreras = await _carreraService.GetSubjectByCareer(idCarrera);
-            return Ok(new { mensaje = "Asignaturas por carrera obtenidas exitosamente.", data = asignaturasCarreras });
         }
 
         // GET: api/Carreras/{id}
@@ -63,7 +57,7 @@ namespace AvaluoAPI.Presentation.Controllers
             return Ok(new { mensaje = "La carrera ha sido actualizada con éxito." });
         }
 
-        [HttpPatch("{id}/peos")]
+        [HttpPatch("peos/{id}")]
         public async Task<IActionResult> UpdatePEOs(int id, [FromBody] string nuevosPEOs)
         {
             if (string.IsNullOrWhiteSpace(nuevosPEOs))


### PR DESCRIPTION
… a asignaturas

- Faltaban los filtros por PEOs y Año en GetCarreras.
- Se agregaron algunos campos que no estaban anteriormente en la consulta de carrera (principalmente del usuario).
- Se movió el método de obtener todas las asignaturas de una carrera al controlador de asignaturas, ya que ahí tiene más sentido.

Extra: Se modificaron los datos de prueba para los roles.