### PR TITLE
Generar informe de desempeño después de insertar la rúbrica

### DIFF
--- a/AvaluoAPI/Infrastructure/Persistence/Repositories/DesempeñoRepositories/DesempeñoRepository.cs
+++ b/AvaluoAPI/Infrastructure/Persistence/Repositories/DesempeñoRepositories/DesempeñoRepository.cs
@@ -94,6 +94,19 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.IDesempeñoRepositor
             return (satisfactorio, porcentaje);
         }
 
+        public async Task<List<int>> ObtenerIdSOPorAsignaturasAsync(int año, string periodo, int idAsignatura)
+        {
+            using var connection = _dapperContext.CreateConnection();
+            string query = "SELECT DISTINCT Id_SO FROM desempeno WHERE Id_Asignatura = @IdAsignatura AND Trimestre = @Trimestre AND Año = @Año;";
+            var asignaturas = await connection.QueryAsync<int>(query, new
+            {
+                IdAsignatura = idAsignatura,
+                Trimestre = periodo,
+                Año = año
+            });
+            return asignaturas.ToList();
+        }
+
         public async Task<IEnumerable<InformeDesempeñoViewModel>> GenerarInformeDesempeño(
     int? año = null, string? periodo = null, int? idAsignatura = null, int? idSO = null)
         {

--- a/AvaluoAPI/Infrastructure/Persistence/Repositories/DesempeñoRepositories/IDesempeñoRepository.cs
+++ b/AvaluoAPI/Infrastructure/Persistence/Repositories/DesempeñoRepositories/IDesempeñoRepository.cs
@@ -9,5 +9,6 @@ namespace AvaluoAPI.Infrastructure.Persistence.Repositories.IDesempeñoRepositor
     {
         Task InsertDesempeños(List<int> asignaturas, int año, string periodo, int estado);
         Task<IEnumerable<InformeDesempeñoViewModel>> GenerarInformeDesempeño(int? año = null, string? periodo = null, int? idAsignatura = null, int? idSO = null);
+        Task<List<int>> ObtenerIdSOPorAsignaturasAsync(int año, string periodo, int idAsignatura);
     }
 }

--- a/AvaluoAPI/Presentation/Controllers/InformesController.cs
+++ b/AvaluoAPI/Presentation/Controllers/InformesController.cs
@@ -42,7 +42,7 @@ namespace AvaluoAPI.Presentation.Controllers
             });
         }
 
-        [HttpGet("informe/vistaPreviaJSON")]
+        [HttpGet("informeDesempeño/vistaPreviaJSON")]
         public async Task<IActionResult> GenerarInformeDesempeño(
             [FromQuery] int? año,
             [FromQuery] string? periodo,
@@ -53,7 +53,7 @@ namespace AvaluoAPI.Presentation.Controllers
             return Ok(new { mensaje = "Informe generado exitosamente", data = informe });
         }
 
-        [HttpGet("informe/vistaPreviaHTML")]
+        [HttpGet("informeDesempeño/vistaPreviaHTML")]
         public async Task<IActionResult> GenerarInformeDesempeñoHtml(
             [FromQuery] int? año,
             [FromQuery] string? periodo,
@@ -65,7 +65,7 @@ namespace AvaluoAPI.Presentation.Controllers
             return View("InformeDesempeño", informe);
         }
 
-        [HttpGet("informe/generarInforme/{anio?}/{periodo?}/{idAsignatura?}/{idSO?}")]
+        [HttpGet("informeDesempeño/generarInforme/{anio?}/{periodo?}/{idAsignatura?}/{idSO?}")]
         public async Task<IActionResult> GenerarInformeDesempeñoPdf(
             [FromRoute] int? anio,
             [FromRoute] string? periodo,


### PR DESCRIPTION
- Primero, se agregó el método ObtenerIdSOPorAsignaturasAsync para obtener los SO que se evaluaron de las asignaturas que se acaban de agregar en desempeño.
- Se modificó DesactivateRubricas() para que consuma un método privado llamado GenerarInforme, el cual realiza exactamente el mismo proceso que el endpoint generarInformeDesempeno, es decir, obtiene los informes según el año, trimestre, asignatura y SO.
- Una vez obtenidos, se genera el informe en HTML haciendo uso de la vista informeDesempeno, y finalmente se utiliza pdfHelper para el manejo de los archivos PDF.